### PR TITLE
Send console output to correct serial device

### DIFF
--- a/eudyptula-boot
+++ b/eudyptula-boot
@@ -262,7 +262,7 @@ start_vm () {
     [ $# -eq 0 ] || echo "exec" "$@" > "$TMP/config/exec"
 
     # Kernel command-line
-    append="console=ttyS0 panic=1 quiet $CMDLINE"
+    append="console=ttyS1 panic=1 $CMDLINE"
     [ -t 1 ] || append="$append noterm=1"
     [ -z "$SILENT" ] || append="$append SILENT=1 loglevel=3"
 


### PR DESCRIPTION
Qemu is configured to treat ttyS1 as a serial device, so this patch
instructs the kernel to use the correct device and disables the quiet
option so that users can see the console output.

Further options could be added, such as 'debug' and 'ignore_loglevel'
for increased debugging, but this should provide a basic working serial
console.
