### PR TITLE
modules: improve search path for kernel modules

### DIFF
--- a/eudyptula-boot
+++ b/eudyptula-boot
@@ -176,7 +176,7 @@ EOF
 
 check_kernel_modules() {
     log_begin_msg "Search for modules"
-    for dir in "$(dirname $KERNEL)/../lib/modules/$VERSION" "$(dirname $KERNEL)/lib/modules/$VERSION" "/lib/modules/$VERSION"; do
+    for dir in "$(dirname $KERNEL)/lib/modules/$VERSION" "$(dirname $KERNEL)/../lib/modules/$VERSION" "$(dirname $KERNEL)/../../lib/modules/$VERSION" "$(dirname $KERNEL)/../../../lib/modules/$VERSION" "/lib/modules/$VERSION"; do
         [ -d $dir ] || continue
         dir="$(readlink -f "$dir")"
         MODULES="$dir"


### PR DESCRIPTION
Add more optional search paths for kernel modules. Since normally bzImage is located under `arch/x86/boot/` search for `lib/modules` must include `$(dirname $KERNEL)/../../../`.

Signed-off-by: Andrey Gelman <andrey.gelman@gmail.com>